### PR TITLE
Update index.html

### DIFF
--- a/files/en-us/web/api/document_object_model/introduction/index.html
+++ b/files/en-us/web/api/document_object_model/introduction/index.html
@@ -202,8 +202,8 @@ table.summary = "note: increased border";
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div style="margin: .5in; height: 400px;"&gt;
-    &lt;p&gt;&lt;b&gt;&lt;code&gt;text&lt;/code&gt;&lt;/b&gt;&lt;/p&gt;
     &lt;form&gt;
+      &lt;p&gt;&lt;b&gt;&lt;code&gt;text&lt;/code&gt;&lt;/b&gt;&lt;/p&gt;
       &lt;select onChange="setBodyAttr('text',
         this.options[this.selectedIndex].value);"&gt;
         &lt;option value="black"&gt;black&lt;/option&gt;


### PR DESCRIPTION
text paragraph is outside of the form element, I think the purpose of the paragraph is to keep the select options separated with a title so the <p><b><code>text</code></b></p> must be inside the form.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
text paragraph is outside of the form element, I think the purpose of the paragraph is to keep the select options separated with a title so the paragraph must be inside the form

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction

> Issue number (if there is an associated issue)

> Anything else that could help us review it
